### PR TITLE
Use a product instead of a combination to generate entropy.

### DIFF
--- a/list.py
+++ b/list.py
@@ -9,7 +9,7 @@ REGION = 'us-west-2'
 
 
 def get_entropies(length, pool='0123456789abcdef'):
-    for each in itertools.combinations_with_replacement(pool, length):
+    for each in itertools.product(pool, repeat=length):
         yield ''.join(each)
 
 


### PR DESCRIPTION
@peterbe r?

Easy way to verify this: there should be 16^3 (= 4096) elements in the list of entropies. With the current code we only get 816. Using the ``product`` function returns the correct number of results. 